### PR TITLE
Fix NameError for health check endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -7,6 +7,7 @@ from generate_index import generate_index
 from xml_parser import parse_xml
 from update_profiles import update_profiles
 from webhook_helpers import send_pilot_stats, send_flight_summary
+from datetime import datetime
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- import `datetime` in `backend/app.py`
- keep timestamp generation via `datetime.utcnow().isoformat()`

## Testing
- `pytest -q`
- `python3 -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846fc3b313c8324afc68f23e743723f