### PR TITLE
Add nickname matcher tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,22 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: pip install pytest
+    - name: Run tests
+      run: pytest -v

--- a/tests/test_nickname_matcher.py
+++ b/tests/test_nickname_matcher.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend.nickname_matcher import resolve_fuzzy_nickname, DEFAULT_FRAGMENTS, normalize_name
+
+
+@pytest.mark.parametrize(
+    "raw_name,expected",
+    [
+        ("Drunk Bonsai", "drunkbonsai"),
+        ("HHC 229 Six", "six"),
+        ("Machinegun 817 Gunner", "machinegun817"),
+        ("Springfield Bones", "bones"),
+        ("Fatal 101st", "fatal"),
+    ],
+)
+def test_resolve_known_names(raw_name, expected):
+    assert resolve_fuzzy_nickname(raw_name, DEFAULT_FRAGMENTS) == expected
+
+
+def test_resolve_unknown_name_returns_normalized():
+    raw = "Unknown Pilot"
+    assert resolve_fuzzy_nickname(raw, DEFAULT_FRAGMENTS) == normalize_name(raw)


### PR DESCRIPTION
## Summary
- add pytest workflow for CI
- add tests for `resolve_fuzzy_nickname`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fdf49c30832497dfcf754ec04dc4