### PR TITLE
Refactor update_profiles API

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -64,7 +64,7 @@ def upload_xml():
             pass  # File cleanup failed, but processing succeeded
         
         if parse_result.get('success', True):  # Assuming parse_xml returns success status
-            update_profiles()
+            update_profiles(filepath)
             generate_index()
             
             return jsonify({

--- a/backend/update_profiles.py
+++ b/backend/update_profiles.py
@@ -14,8 +14,9 @@ def update_profiles_from_xml(xml_path, profile_dir):
         update_profile(profile, mission_data, flight_minutes=45, aircraft=aircraft)
         save_profile(nickname, profile, profile_dir)
 
-def update_profiles():
-    xml_path = Path("pilot_profiles/temp_upload.xml")
+def update_profiles(xml_path):
+    """Update pilot profiles using data from the provided Tacview XML file."""
+    xml_path = Path(xml_path)
     out_dir = Path("pilot_profiles")
     update_profiles_from_xml(xml_path, out_dir)
 


### PR DESCRIPTION
## Summary
- update `update_profiles` to accept a path to the uploaded XML file
- call `update_profiles(filepath)` from the upload endpoint

## Testing
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6849b4a0e400832483c7ec1d523ce3a6