### PR TITLE
Add vite dev dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,8 @@
         "tailwindcss": "^4.1.7"
       },
       "devDependencies": {
-        "vite-tsconfig-paths": "^5.1.4"
+        "vite-tsconfig-paths": "^5.1.4",
+        "vite": "^6.3.5"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "tailwindcss": "^4.1.7"
   },
   "devDependencies": {
+    "vite": "^6.3.5",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }


### PR DESCRIPTION
## Summary
- add vite as a dev dependency
- update lockfile accordingly

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b56495d483248caf56cb0ebf9baf